### PR TITLE
Use `partial` call to include partial templates

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,7 +1,7 @@
-{{ template "theme/partials/head.html" . }}
+{{ partial "head.html" . }}
 <body>
 
-{{ template "theme/partials/sidebar.html" . }}
+{{ partial "sidebar.html" . }}
 
     <div class="content container">
   <ul class="posts">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,7 +1,7 @@
-{{ template "theme/partials/head.html" . }}
+{{ partial "head.html" . }}
 <body>
 
-{{ template "theme/partials/sidebar.html" . }}
+{{ partial "sidebar.html" . }}
 
     <div class="content container">
 <div class="post">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
-{{ template "theme/partials/head.html" . }}
+{{ partial "head.html" . }}
 <body>
 
-{{ template "theme/partials/sidebar.html" . }}
+{{ partial "sidebar.html" . }}
 
     <div class="content container">
 <div class="posts">


### PR DESCRIPTION
Replace `template` call with the `partial` call (new in Hugo v0.12)
for including partial templates
