### PR TITLE
Lowercase variables for .Site.Params

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -3,7 +3,7 @@
     <div class="sidebar-about">
       <h1>{{ .Site.Title }}</h1>
       <p class="lead">
-      {{ with .Site.Params.Description }} {{.}} {{ else }}An elegant open source and mobile first theme for <a href="http://hugo.spf13.com">hugo</a> made by <a href="http://twitter.com/mdo">@mdo</a>. Originally made for Jekyll.{{end}}
+      {{ with .Site.Params.description }} {{.}} {{ else }}An elegant open source and mobile first theme for <a href="http://hugo.spf13.com">hugo</a> made by <a href="http://twitter.com/mdo">@mdo</a>. Originally made for Jekyll.{{end}}
       </p>
     </div>
 
@@ -14,6 +14,6 @@
       {{end}}
     </ul>
 
-    <p>{{ with .Site.Params.Copyright }}{{.}}{{ else }}&copy; {{.Now.Format "2006"}}. All rights reserved. {{end}}</p>
+    <p>{{ with .Site.Params.copyright }}{{.}}{{ else }}&copy; {{.Now.Format "2006"}}. All rights reserved. {{end}}</p>
   </div>
 </div>


### PR DESCRIPTION
Variables under .Site.Params are accessed with all lower-case identifiers. Hugo won't find them with an upper-case first letter, regardless of how they're formatted in the site `config` file.