### PR TITLE
Fetch Google fonts over https to avoid mixed contents warnings

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/poole.css">
   <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/syntax.css">
   <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/hyde.css">
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/apple-touch-icon-144-precomposed.png">


### PR DESCRIPTION
Fetch Google fonts over https to avoid mixed contents warnings.