### PR TITLE
Corrected link to favicon image

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,7 +17,7 @@
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/apple-touch-icon-144-precomposed.png">
-  <link rel="shortcut icon" href="/favicon.ico">
+  <link rel="shortcut icon" href="/favicon.png">
 
   <!-- RSS -->
   <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />


### PR DESCRIPTION
The original reference was to favicon.ico, when the provided image is .png