### PR TITLE
Replaced .Url with .URL in sidebar.html

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -10,7 +10,7 @@
     <ul class="sidebar-nav">
       <li><a href="/">Home</a> </li>
       {{ range .Site.Menus.main }}
-        <li><a href="{{.Url}}"> {{ .Name }} </a></li>
+        <li><a href="{{.URL}}"> {{ .Name }} </a></li>
       {{end}}
     </ul>
 


### PR DESCRIPTION
This should avoid the annoying error message. Furthermore will `.Url` be incompatible with Hugo v0.15.