### PR TITLE
Replace deprecated template variable name

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,9 +10,9 @@
   <title> {{ .Title }} &middot; {{ .Site.Title }} </title>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/poole.css">
-  <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/syntax.css">
-  <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/hyde.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/poole.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/syntax.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/hyde.css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
   <!-- Icons -->


### PR DESCRIPTION
When running hugo with the hyde template, it generates warnings about BaseUrl being deprecated
in favor of BaseURL.