### PR TITLE
Remove double-slashes in stylesheet URLs

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,9 +11,9 @@
   <title> {{ .Title }} &middot; {{ .Site.Title }} </title>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/poole.css">
-  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/syntax.css">
-  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/hyde.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}css/poole.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}css/syntax.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}css/hyde.css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
   <!-- Icons -->


### PR DESCRIPTION
AWS S3 doesn't like to serve these files when the URL is `example.com//css/poole.css`. It looks like `{{ .Site.BaseURL }}` has a trailing slash, so I removed the slash before `css/poole.css`. The resulting URL is `example.com/css/poole.css`, and AWS S3 plays nice with that.