### PR TITLE
Use language from configuration.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
+<html xmlns="http://www.w3.org/1999/xhtml"{{with .Site.LanguageCode}} xml:lang="{{.}}" lang="{{.}}"{{end}}>
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">


### PR DESCRIPTION
The header should use the language supplied in the configuration rather than hardcoding to english (US).