### PR TITLE
Add layout-reverse body class code to single and list templates.

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,5 @@
 {{ partial "head.html" . }}
-<body class="{{ .Site.Params.themeColor }}">
+<body class="{{ .Site.Params.themeColor }} {{if .Site.Params.layoutReverse}}layout-reverse{{end}}">
 
 {{ partial "sidebar.html" . }}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 	{{ partial "head.html" . }}
-	<body class="{{ .Site.Params.themeColor }}">
+	<body class="{{ .Site.Params.themeColor }} {{if .Site.Params.layoutReverse}}layout-reverse{{end}}">
 		{{ partial "sidebar.html" . }}
 
 		<div class="content container">


### PR DESCRIPTION
List and single templates currently ignore the reverse layout parameter. This brings them inline with the index template.