### PR TITLE
don't repeat title in <title> tag on the home page

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,7 +8,11 @@
   <!-- Enable responsiveness on mobile devices-->
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 
-  <title> {{ .Title }} &middot; {{ .Site.Title }} </title>
+  {{ if .IsHome }}
+  <title>{{ .Site.Title }}</title>
+  {{ else }}
+  <title>{{ .Title }} &middot; {{ .Site.Title }}</title>
+  {{ end }}
 
   <!-- CSS -->
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/poole.css">


### PR DESCRIPTION
Now if the title of a blog is "Title", then its `<title>` tag looks like this: `<title> Title &middot; Title </title>`. This pull request prevents that from happening (and removes the surrounding single spaces).
