### PR TITLE
Fixed printing issues

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,6 +15,7 @@
   {{ end }}
 
   <!-- CSS -->
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}css/print.css">
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/poole.css">
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/syntax.css">
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/hyde.css">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,7 +15,7 @@
   {{ end }}
 
   <!-- CSS -->
-  <link rel="stylesheet" href="{{ .Site.BaseURL }}css/print.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}css/print.css" media="print">
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/poole.css">
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/syntax.css">
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/hyde.css">

--- a/static/css/print.css
+++ b/static/css/print.css
@@ -1,0 +1,19 @@
+.sidebar {
+  display: none !important;
+}
+
+.content {
+  margin: 0 auto;
+  width: 100%;
+  float: none;
+  display: initial;
+}
+
+.container {
+  width: 100%;
+  float: none;
+  display: initial;
+  padding-left:  1rem;
+  padding-right: 1rem;
+  margin: 0 auto;
+}


### PR DESCRIPTION
On the original Jekyll Hyde theme, this theme and its fork Hyde-X, printing results in either of the following issues (depending on the browser):
1. Half the page filled with a sidebar (see attached screenshot), or
2. Plenty of extra blank pages to be printed at the end.
<img width="232" alt="jh" src="https://cloud.githubusercontent.com/assets/24285550/21748163/6fda96de-d532-11e6-8a08-c41d7956063d.png">
I added a print media specific CSS and printing works without issue now, but excludes the sidebar completely.