### PR TITLE
Replacing deprecated function call with now preferred version

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -14,6 +14,6 @@
       {{end}}
     </ul>
 
-    <p>{{ with .Site.Params.copyright }}{{.}}{{ else }}&copy; {{.Now.Format "2006"}}. All rights reserved. {{end}}</p>
+    <p>{{ with .Site.Params.copyright }}{{.}}{{ else }}&copy; {{ now.Format "2006"}}. All rights reserved. {{end}}</p>
   </div>
 </div>


### PR DESCRIPTION
Using the old call was producing the following Warning:

WARNING: Page's Now is deprecated and will be removed in a future
release. Use now (the template func).