### PR TITLE
Update link to Hugo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hyde
 
-Hyde is a brazen two-column [hugo](http://hugo.spf13.com) theme based on the [Jekyll](http://jekyllrb.com) theme of the same name.
+Hyde is a brazen two-column [hugo](https://gohugo.io) theme based on the [Jekyll](http://jekyllrb.com) theme of the same name.
 It pairs a prominent sidebar with uncomplicated content.
 
 ![Hyde screenshot](https://f.cloud.github.com/assets/98681/1831228/42af6c6a-7384-11e3-98fb-e0b923ee0468.png)


### PR DESCRIPTION
The http://hugo.spf13.com is unreachable. By the context, the https://gohugo.io will be appropriate.