### PR TITLE
Implement Content Summaries / Split on index page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,7 +6,12 @@
     <a href="{{ .Permalink }}">{{ .Title }}</a>
   </h1>
   <span class="post-date">{{ .Date.Format "Mon, Jan 2, 2006" }}</span>
-  {{ .Content }}
+  {{ .Summary }}
+  {{ if .Truncated }}
+  <div class="read-more-link">
+    <a href="{{ .RelPermalink }}">Read More…</a>
+  </div>
+  {{ end }}
 </div>
 {{- end }}
 </div>


### PR DESCRIPTION
Posts in the index page will be automatically summarized to its first 70
words, or until a user-defined <!--more--> divider. When summarized, the
"Read More" button also appears with a RelPermalink to the full post.

https://gohugo.io/content-management/summaries/