### PR TITLE
Add Quick Start Forestry Button to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To give you a running start this installation puts a fully configured [starter r
 
 _Forestry Starter-Kit:_
 
-[![Import this project into Forestry](https://assets.forestry.io/import-to-forestry.svg)](https://app.forestry.io/quick-start?repo=forestryio/hyde-hugo-starter&provider=github&engine=hugo&version=0.42)
+[![Import this project into Forestry](https://assets.forestry.io/import-to-forestry.svg)](https://app.forestry.io/quick-start?repo=forestryio/hyde-hugo-starter&provider=github&engine=hugo&version=0.49)
 
 ### Standard Installation
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ It pairs a prominent sidebar with uncomplicated content.
 
 ## Installation
 
+### Quick Start
+
+To give you a running start this installation puts a fully configured [starter repo](https://github.com/forestryio/hyde-hugo-starter) into your Account and imports it into the [Forestry](https://forestry.io) Content Manager. 
+
+_Forestry Starter-Kit:_
+
+[![Import this project into Forestry](https://assets.forestry.io/import-to-forestry.svg)](https://app.forestry.io/quick-start?repo=forestryio/hyde-hugo-starter&provider=github&engine=hugo&version=0.42)
+
+### Standard Installation
+
 To install Hyde as your default theme, first install this repository in the `themes/` directory:
 
     $ cd themes/

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ It pairs a prominent sidebar with uncomplicated content.
 
 ### Quick Start
 
-To give you a running start this installation puts a fully configured [starter repo](https://github.com/forestryio/hyde-hugo-starter) into your Account and imports it into the [Forestry](https://forestry.io) Content Manager. 
+To give you a running start this installation puts a fully configured [starter repo](https://github.com/forestryio/hyde-hugo-starter) into your Git account and sets it up in a content manager / CMS. 
 
-_Forestry Starter-Kit:_
+_[Forestry](https://forestry.io) Starter-Kit:_
 
 [![Import this project into Forestry](https://assets.forestry.io/import-to-forestry.svg)](https://app.forestry.io/quick-start?repo=forestryio/hyde-hugo-starter&provider=github&engine=hugo&version=0.49)
 


### PR DESCRIPTION
Hi,

Thanks for porting and maintaining this theme. I've created a starter-kit for Hyde + Hugo + Forestry and I think this could help people get up & running quickly.

This change adds a button to the Readme file that imports the starter-kit to a git provider and into Forestry. Once imported there's also instructions on how to easily deploy the site with Netlify (to give those users that are new to static sites a little bit of guidance on how to finalize their setup).

Let me know if this would work for you or if you need any changes.