### PR TITLE
Removed deprecated .Hugo and .RSSLink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,7 +3,7 @@
 <head>
   <link href="//gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  {{ .Hugo.Generator }}
+  {{ hugo.Generator }}
 
   <!-- Enable responsiveness on mobile devices-->
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -25,8 +25,10 @@
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/apple-touch-icon-144-precomposed.png">
   <link rel="shortcut icon" href="/favicon.png">
 
-  <!-- RSS -->
-  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  <!-- RSS etc -->
+  {{ range .AlternativeOutputFormats -}}
+    {{ printf `<link href="%s" rel="%s" type="%s" title="%s" />` .Permalink .Rel .MediaType.Type $.Site.Title | safeHTML }}
+  {{ end -}}
 
   {{ partial "hook_head_end.html" . }}
 </head>

--- a/theme.toml
+++ b/theme.toml
@@ -4,7 +4,7 @@ licenselink = "https://github.com/spf13/hyde/blob/master/LICENSE.md"
 description = "An elegant open source and mobile first theme"
 tags = ["blog", "company"]
 features = ["blog", "themes", "disqus"]
-min_version = 0.21
+min_version = 0.53
 
 [author]
     name = "spf13"


### PR DESCRIPTION
Latest Hugo showed deprecation warning messages:

```
Building sites … WARN 2019/04/27 15:48:17 Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.
WARN 2019/04/27 15:48:17 Page's .RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like: 
    {{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}.
```

Change has been tested with Hugo v0.53 and Hugo v0.55.4 (latest) and it's breaking compatibility with Hugo v0.52 and below.

Some details: https://github.com/gohugoio/hugo/issues/5467