### PR TITLE
Configurable date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It pairs a prominent sidebar with uncomplicated content.
   - [Sticky sidebar content](#sticky-sidebar-content)
   - [Themes](#themes)
   - [Reverse layout](#reverse-layout)
+  - [Custom date format](#custom-date-format)
   - [Disqus](#disqus)
   - [Google Analytics](#google-analytics)
 - [Author](#author)
@@ -127,6 +128,28 @@ theme: "hyde"
 params:
   layoutReverse: true
 ```
+
+### Custom date format
+
+To change the date format, add the `dateFormat` variable under `params`, the value must be a valid [Go layout string](https://golang.org/pkg/time/), like so:
+
+**TOML**
+```toml
+theme = "hyde"
+
+[params]
+  dateFormat = "Jan 2, 2006"
+```
+
+**YAML**
+```yaml
+theme: "hyde"
+
+params:
+  dateFormat: "Jan 2, 2006"
+```
+
+Default value: `Mon, Jan 2, 2006`
 
 ### Disqus
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,7 @@
 <ul class="posts">
 {{ range .Data.Pages -}}
   <li>
-    <span><a href="{{ .Permalink }}">{{ .Title }}</a> <time class="pull-right post-list" datetime="{{ .Date.Format "2006-01-02T15:04:05Z0700" }}">{{ .Date.Format "Mon, Jan 2, 2006" }}</time></span>
+    <span><a href="{{ .Permalink }}">{{ .Title }}</a> <time class="pull-right post-list" datetime="{{ .Date.Format "2006-01-02T15:04:05Z0700" }}">{{ $df := .Site.Params.dateFormat | default "Mon, Jan 2, 2006" }}{{ .Date.Format $df }}</time></span>
   </li>
 {{- end }}
 </ul>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,7 +1,7 @@
 {{ define "main" -}}
 <div class="post">
   <h1>{{ .Title }}</h1>
-  <time datetime={{ .Date.Format "2006-01-02T15:04:05Z0700" }} class="post-date">{{ .Date.Format "Mon, Jan 2, 2006" }}</time>
+  <time datetime={{ .Date.Format "2006-01-02T15:04:05Z0700" }} class="post-date">{{ $df := .Site.Params.dateFormat | default "Mon, Jan 2, 2006" }}{{ .Date.Format $df }}</time>
   {{ .Content }}
 </div>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,7 +5,7 @@
   <h1 class="post-title">
     <a href="{{ .Permalink }}">{{ .Title }}</a>
   </h1>
-  <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z0700" }}" class="post-date">{{ .Date.Format "Mon, Jan 2, 2006" }}</time>
+  <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z0700" }}" class="post-date">{{ $df := .Site.Params.dateFormat | default "Mon, Jan 2, 2006" }}{{ .Date.Format $df }}</time>
   {{ .Summary }}
   {{ if .Truncated }}
   <div class="read-more-link">


### PR DESCRIPTION
Added a new variable: `params.dateFormat`, if it's not set it will default to `Mon, Jan 2, 2006` to keep backward compatibility.