### PR TITLE
Adjusted pages lookup compatibility

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ define "main" -}}
 <div class="posts">
-{{ range .Site.RegularPages -}}
+{{ range (.Site.RegularPages | default .Data.Pages) -}}
 <article class="post">
   <h1 class="post-title">
     <a href="{{ .Permalink }}">{{ .Title }}</a>


### PR DESCRIPTION
# What
Adjusting the index page to show all the posts in descending order in the version [v0.57.0](https://github.com/gohugoio/hugo/releases/tag/v0.57.0) of Hugo.

# Why
After the changes in gohugoio/hugo#6181 included in the version v0.57.0 of Hugo the index page doesn't have `.Data.Pages` variable anymore.

*This change keeps retro-compatibility with previous versions of Hugo.*