### PR TITLE
fix(heads): Add protocol to gmpg URL

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"{{with .Site.LanguageCode}} xml:lang="{{.}}" lang="{{.}}"{{end}}>
 <head>
-  <link href="//gmpg.org/xfn/11" rel="profile">
+  <link href="https://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
   {{ hugo.Generator }}
 


### PR DESCRIPTION
The resource is available over HTTPS.

https://webhint.io/docs/user-guide/hints/hint-no-protocol-relative-urls/