### PR TITLE
Add meta description to header

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,6 +13,7 @@
   {{- else -}}
   <title>{{ .Title }} &middot; {{ .Site.Title }}</title>
   {{- end }}
+  <meta name="description" content="{{if .IsHome}}{{ $.Site.Params.description }}{{else}}{{.Description}}{{end}}" />
 
   <!-- CSS -->
   <link type="text/css" rel="stylesheet" href="{{ .Site.BaseURL }}css/print.css" media="print">


### PR DESCRIPTION
Based on hugo docs: https://gohugo.io/variables/site/#example-site-params
And developers.google recommendations: https://developers.google.com/web/tools/lighthouse/audits/description?utm_source=lighthouse&utm_medium=devtools