### PR TITLE
fix(static/css/poole): Contrast issues

### DIFF
--- a/static/css/poole.css
+++ b/static/css/poole.css
@@ -68,7 +68,7 @@ body {
 
 /* No `:visited` state is required by default (browsers will use `a`) */
 a {
-  color: #268bd2;
+  color: #227bb9;
   text-decoration: none;
 }
 /* `:focus` is linked to `:hover` for basic accessibility */
@@ -153,7 +153,7 @@ pre {
 code {
   padding: .25em .5em;
   font-size: 85%;
-  color: #bf616a;
+  color: #b3555e;
   background-color: #f9f9f9;
   border-radius: 3px;
 }
@@ -323,7 +323,7 @@ tbody tr:nth-child(odd) th {
   display: block;
   margin-top: -.5rem;
   margin-bottom: 1rem;
-  color: #9a9a9a;
+  color: #757575;
 }
 
 /* Related posts */
@@ -344,7 +344,7 @@ tbody tr:nth-child(odd) th {
   color: #999;
 }
 .related-posts li a:hover {
-  color: #268bd2;
+  color: #227bb9;
   text-decoration: none;
 }
 .related-posts li a:hover small {


### PR DESCRIPTION
Ensures that the contrast ratio is at least 4.5:1 (so that is complies with [WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html)).The visual difference is minimal (see attached screenshots: left is before, right is after). I would make this change upstream but the project seems abandoned.

<div>
<img src="https://user-images.githubusercontent.com/2109702/69442212-7633c000-0d4c-11ea-8613-7e0bbbb9b23a.png" width="300" alt="preview before this change"/>

<img src="https://user-images.githubusercontent.com/2109702/69442222-792eb080-0d4c-11ea-82bf-4fcceaa5471b.png" width="300" alt="preview after this change"/>
</div>
