### PR TITLE
Update baseof.html

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -5,6 +5,8 @@
     {{ block "main" . -}}{{- end }}
     </main>
 
-    {{ template "_internal/google_analytics_async.html" . }}
+    {{ if not .Site.IsServer }}
+      {{ template "_internal/google_analytics_async.html" . }}
+    {{ end }}
   </body>
 </html>


### PR DESCRIPTION
Don't publish analytics events during development
Solution from https://discourse.gohugo.io/t/how-to-exclude-google-analytics-when-running-under-hugo-local-server/6092/34