### PR TITLE
add umami analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It pairs a prominent sidebar with uncomplicated content.
   - [Reverse layout](#reverse-layout)
   - [Disqus](#disqus)
   - [Google Analytics](#google-analytics)
+  - [Umami Analytics](#umami-analytics)
 - [Author](#author)
 - [Ported by](#ported-by)
 - [License](#license)
@@ -200,6 +201,17 @@ googleAnalytics = "Your tracking code"
 **YAML**
 ```yaml
 googleAnalytics: Your tracking code
+```
+
+## Umami Analytics
+
+If using [umami-analytics](https://umami.is/) add the following lines to your config.toml file:
+
+```toml
+[params.umami]
+  enabled = true
+  dataWebsiteId="your-web-site-id"
+  src="https://analytics.umami.is/script.js"
 ```
 
 ## Author

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,6 +20,12 @@
   <link type="text/css" rel="stylesheet" href="{{ .Site.BaseURL }}css/poole.css">
   <link type="text/css" rel="stylesheet" href="{{ .Site.BaseURL }}css/syntax.css">
   <link type="text/css" rel="stylesheet" href="{{ .Site.BaseURL }}css/hyde.css">
+
+  <!-- UMAMI -->
+  {{ if .Site.Params.Umami.Enabled -}}
+    <script async defer src="{{.Site.Params.Umami.Src}}" data-website-id="{{.Site.Params.Umami.DataWebsiteId}}"></script>
+  {{- end }}
+
   {{ partial "head_fonts.html" . }}
 
   <!-- Icons -->


### PR DESCRIPTION
This change allows to setup [umami](https://umami.is/) , an [open source](https://github.com/umami-software/umami), privacy-focused alternative to Google Analytics