### PR TITLE
fixes a page load error due to deprication of .SiteDisqusShortname

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,7 +5,7 @@
   {{ .Content }}
 </div>
 
-{{ if .Site.DisqusShortname -}}
+{{ if .Site.Config.Services.Disqus.Shortname -}}
 <h2>Comments</h2>
 {{ template "_internal/disqus.html" . }}
 {{- end }}


### PR DESCRIPTION
I'm trying out your theme and ran into the following error when I set draft to false:

ERROR deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.136.0. Use .Site.Config.Services.Disqus.Shortname instead.
Built in 27 ms
Error: error building site: logged 1 error(s)

I'm on the following version:
hugo v0.135.0-DEV-0ea796dad11e5d9f5b4c96a8e65f8272c9e4ccb5+extended

I don't see .Site.DisqusShortname used elsewhere, so it looks like this fixes it.