### PR TITLE
fix(layouts/single) Site.DisqusShortname was deprecated in v0.120.0

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,7 +5,7 @@
   {{ .Content }}
 </div>
 
-{{ if .Site.DisqusShortname -}}
+{{ if .Site.Config.Services.Disqus.Shortname -}}
 <h2>Comments</h2>
 {{ template "_internal/disqus.html" . }}
 {{- end }}


### PR DESCRIPTION
## Update Disqus Shortname to Use New Config Structure

### Summary
This pull request updates the Disqus shortname configuration in the `single.html` template to follow Hugo's new configuration structure. The previous `Site.DisqusShortname` has been deprecated and replaced by `Site.Config.Services.Disqus.Shortname`.

For more details, please refer to the [Hugo_methods_ DisqusShortname](https://gohugo.io/methods/site/disqusshortname/) integration.

### Errors Details

> Testing in Alpine based container.

```bash
hugo_builder  | ERROR deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.135.0. Use .Site.Config.Services.Disqus.Shortname instead.
```
This error occurred when attempting to render the single.html template for posts that include Disqus comments. By updating to the new configuration structure, the error is resolved, and future compatibility with Hugo is ensured.


### Changes:
- Updated the condition in `single.html` from `Site.DisqusShortname` to `Site.Config.Services.Disqus.Shortname`.
- Adjusted the `config.toml` to reflect the new Disqus shortname structure:
  ```toml
  [services]
    [services.disqus]
      shortname = "your-disqus-shortname"


Thanks! Have a Good day!!😄 