### PR TITLE
Fix name collision with bundled css.

### DIFF
--- a/layouts/partials/head_css.html
+++ b/layouts/partials/head_css.html
@@ -3,6 +3,6 @@
 {{- with  (resources.Get "css/custom.css") }}
   {{ $others = $others | append  . }}
 {{- end }}
-{{- $other := $others | resources.Concat "css/hyde.css" }}
+{{- $other := $others | resources.Concat "css/hyde-bundle.css" }}
 {{- partial "head_css_link_resource.html" (dict "resource" $other) }}
 {{- partial "head_fonts.html" . -}}


### PR DESCRIPTION
With both one source and the output named "hyde.css", the source was being returned and all bundle contents and customizations ignored.